### PR TITLE
Bump gophercloud to 0.13.0 and use official repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module github.com/Lirt/velero-plugin-swift
 go 1.14
 
 require (
-	github.com/gophercloud/gophercloud v0.12.2
+	github.com/gophercloud/gophercloud v0.13.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.4.0
 	github.com/vmware-tanzu/velero v1.4.2
 )
 
-replace github.com/gophercloud/gophercloud => github.com/Lirt/gophercloud v0.12.2


### PR DESCRIPTION
The temporary one was used until the fix for velero temp-url was
released

Signed-off-by: Ondrej Vasko <ondrej.vaskoo@gmail.com>